### PR TITLE
Bt4 tpl

### DIFF
--- a/extra/Templates for bootstrap 4/xmsocial/xmsocial_social.tpl
+++ b/extra/Templates for bootstrap 4/xmsocial/xmsocial_social.tpl
@@ -1,6 +1,6 @@
-<div class="row">
+<div class="row bg-secondary rounded pt-2 pb-1 mt-1 mx-auto text-truncate justify-content-between">
 <{foreach item=itemsocial from=$social_arr}>
-	<div class="col-6 col-md-4 col-lg-3">
+	<div class="col-12 col-lg-6 mb-1 mb-lg-0">
 		<{$itemsocial}>
 	</div>
 <{/foreach}>

--- a/extra/Templates for bootstrap 4/xmsocial/xmsocial_social.tpl
+++ b/extra/Templates for bootstrap 4/xmsocial/xmsocial_social.tpl
@@ -1,6 +1,6 @@
-<div class="row bg-secondary rounded pt-2 pb-1 mt-1 mx-auto text-truncate justify-content-between">
+<div class="d-flex flex-row my-1 mx-auto flex-wrap align-items-center">
 <{foreach item=itemsocial from=$social_arr}>
-	<div class="col-12 col-lg-6 mb-1 mb-lg-0">
+	<div class="mr-1 mb-1">
 		<{$itemsocial}>
 	</div>
 <{/foreach}>


### PR DESCRIPTION
Si tu ne veux pas de fond sous les icônes des réseaux sociaux, 
il suffit d'enlever "bg-secondary".

RAS pour le template par défaut pour xswatch (bt3)